### PR TITLE
:sparkles: Make whole navigation panel clickable on Homepage

### DIFF
--- a/assets/styles/business/call-to-action.scss
+++ b/assets/styles/business/call-to-action.scss
@@ -18,3 +18,12 @@
   background-color: $gun-powder !important;
   color: white !important;
 }
+
+.call-to-action-container {
+  cursor: pointer;
+}
+
+.call-to-action-container:hover .call-to-action {
+  background-color: $gun-powder !important;
+  color: white !important;
+}

--- a/layouts/partials/core/scripts.html
+++ b/layouts/partials/core/scripts.html
@@ -41,6 +41,11 @@
 
 <script
   type="application/javascript"
+  src="/js/call-to-action.js"
+></script>
+
+<script
+  type="application/javascript"
   src="/js/bulma-carousel/bulma-carousel.min.js"
 ></script>
 

--- a/layouts/partials/views/home/nav.html
+++ b/layouts/partials/views/home/nav.html
@@ -1,13 +1,13 @@
 <section class="container my-6">
   <div class="columns is-variable is-8">
     <div class="column is-one-third">
-      <div class="panel is-radiusless is-full-height">
-        <a
-          class="panel-block button call-to-action has-text-centered is-justify-content-center"
-          href="/getting-started/"
-        >
+      <div
+        class="panel call-to-action-container is-radiusless is-full-height"
+        data-call-to-action="/getting-started/"
+      >
+        <p class="panel-block button call-to-action has-text-centered is-justify-content-center">
           Getting Started
-        </a>
+        </p>
         <div class="panel-block">
           <div class="container">
             <div class="content p-3">
@@ -20,13 +20,13 @@
       </div>
     </div>
     <div class="column is-one-third">
-      <div class="panel is-radiusless is-full-height">
-        <a
-          class="panel-block button call-to-action has-text-centered is-justify-content-center"
-          href="/offers/"
-        >
+      <div
+        class="panel call-to-action-container is-radiusless is-full-height"
+        data-call-to-action="/offers/"
+      >
+        <p class="panel-block button call-to-action has-text-centered is-justify-content-center">
           Product and services
-        </a>
+        </p>
         <div class="panel-block">
           <div class="container">
             <div class="content p-3">
@@ -39,13 +39,13 @@
       </div>
     </div>
     <div class="column is-one-third">
-      <div class="panel is-radiusless is-full-height">
-        <a
-          class="panel-block button call-to-action has-text-centered is-justify-content-center"
-          href="/docs/"
-        >
+      <div
+        class="panel call-to-action-container is-radiusless is-full-height"
+        data-call-to-action="/docs/"
+      >
+        <p class="panel-block button call-to-action has-text-centered is-justify-content-center">
           Documentation
-        </a>
+        </p>
         <div class="panel-block">
           <div class="container">
             <div class="content p-3">

--- a/static/css/kubirds.css
+++ b/static/css/kubirds.css
@@ -15346,6 +15346,15 @@ html, body {
   color: white !important;
 }
 
+.call-to-action-container {
+  cursor: pointer;
+}
+
+.call-to-action-container:hover .call-to-action {
+  background-color: #464159 !important;
+  color: white !important;
+}
+
 .kubirds-description-banner {
   background-image: url("/img/getting-started/description-background.jpg");
   background-attachment: fixed;

--- a/static/js/call-to-action.js
+++ b/static/js/call-to-action.js
@@ -1,0 +1,6 @@
+$(() => {
+  $('*[data-call-to-action]').click(function() {
+    const el = $(this)
+    window.location.href = el.data('call-to-action')
+  })
+})


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: Add `call-to-action.js` script to make element with `data-call-to-action` attribute clickable
 - [x] :lipstick: Add `.call-to-action-container` class to control child `.call-to-action`
 - [x] :recycle: Make navigation panels on homepage clickable